### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ratfor Software Tools Framework
 
+![K&P Software Tools CI](https://github.com/rextanka/ratfor/actions/workflows/main.yml/badge.svg)
+
 This repository contains a modern implementation of the tools from Kernighan & Plauger's *Software Tools* (1976). Since the original code is in Ratfor (Rational Fortran), this project uses a custom Python transpiler to target modern C.
 
 ## Project Structure


### PR DESCRIPTION
Description Finalizing the CI/CD pipeline by adding a visual status indicator to the project home page. This ensures the health of the Ratfor-to-C transpiler is visible at a glance.

Changes
Updated README.md to include the GitHub Actions status badge.
Pointed the badge to the main.yml workflow for real-time tracking.
Verification
[ ] Badge renders correctly in PR preview.
[ ] Links correctly to the Actions tab.